### PR TITLE
Don't install runtime dependencies during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,13 @@ clean:
 
 install_runtime_dependencies: /QOpenSys/pkgs/bin/db2util /QOpenSys/pkgs/lib/jvm/openjdk-11/bin/java /QOpenSys/pkgs/bin/nohup
 
+install_with_runtime_dependencies: install install_runtime_dependencies
+
 man/man.1: man/man.header man/man.mansrc
 	rm -f man/man.1
 	cat man/man.header man/man.mansrc > man/man.1
 
-install: scripts/sc scripts/scinit scripts/sc_install_defaults target/sc.jar install_runtime_dependencies man/man.1
+install: scripts/sc scripts/scinit scripts/sc_install_defaults target/sc.jar man/man.1
 	install -m 755 -o qsys -D -d ${INSTALL_ROOT}/QOpenSys/pkgs/bin ${INSTALL_ROOT}/QOpenSys/pkgs/lib/sc ${INSTALL_ROOT}/QOpenSys/etc/sc ${INSTALL_ROOT}/QOpenSys/etc/sc/services
 	chmod 755 ${INSTALL_ROOT}/QOpenSys/etc/sc ${INSTALL_ROOT}/QOpenSys/etc/sc/services
 	chown -R qsys ${INSTALL_ROOT}/QOpenSys/etc/sc

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Service Commander's unique design is intended to offer a great deal of flexibili
 
 ## System Requirements
 
-For most of the features of this tool, the following is required to be installed (the `make install` of the installation steps should handle these for you):
+For most of the features of this tool, the following is required to be installed (the `make install_with_runtime_dependencies` of the installation steps should handle these for you):
 - db2util (`yum install db2util`)
 - OpenJDK (`yum install openjdk-11`)
 - bash (`yum install bash`)
@@ -83,7 +83,7 @@ The build itself can be done with the following steps:
 yum install git ca-certificates-mozilla make-gnu
 git clone https://github.com/ThePrez/ServiceCommander-IBMi/
 cd ServiceCommander-IBMi
-make install
+make install_with_runtime_dependencies
 ```
 
 # Basic usage


### PR DESCRIPTION
Instead make a separate target which does the previous install behavior
and and tell users to use that.
