### PR TITLE
bugfix: `scopenports` not handling IPv6 properly (#88)

### DIFF
--- a/service-commander.spec
+++ b/service-commander.spec
@@ -65,6 +65,9 @@ fi
 %{_mandir}/man1/sc.*
 
 %changelog
+* Wed Dec 29 2021 Jesse Gorzinski <jgorzins@us.ibm.com> - 0.7.2
+- bugfix: scopenports not handling ipv6 properly
+
 * Wed Dec 29 2021 Jesse Gorzinski <jgorzins@us.ibm.com> - 0.7.1
 - bugfix: sc_install_defaults produced invalid configs
 

--- a/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
+++ b/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
@@ -267,7 +267,7 @@ public class ServiceCommander {
             _logger.println("---------------  ------  --------------------------------------------");
             for (final String addr : addrs) {
                 Integer port = Integer.valueOf(addr.replaceAll(".*:", ""));
-                String ip = addr.replaceAll(":.*", "");
+                String ip = addr.replaceAll(":[^:]+", "");
                 final ServiceDefinition svcDef = getAdHocServiceDef("port:" + port, serviceDefs, _logger);
                 String line = StringUtils.spacePad(ip, 17);
                 line += StringUtils.spacePad(""+port, 8);


### PR DESCRIPTION
Fixes #88 
