### PR TITLE
Fix lock situation in STRTCPSVR

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,18 @@ After doing so, you can run the `*SC` TCP server commands, specifying the simple
 STRTCPSVR SERVER(*SC) INSTANCE('kafka')
 ```
 
+**Running two or more STRTCPSVR commands simultaneously**
+
+Be aware that running two or more STRTCPSVR commands at the same time in different jobs can cause the command to fail with TCP1A11. This is because the system will only run one STRTCPSVR command at a time and uses an internal locking mechanism to control this. The wait time is 30 seconds, and if STRTCPSVR in job A is taking longer to start the service, the STRTCPSVR in job B and C etc. will time out when aquiring the lock.
+
+If you need to run more than one STRTCPSVR *SC command at a time (e.g. after IPL where the system is busy and the service can take longer to start), you can reduce the lock time significantly by setting an environment variable before running the STRTCPSVR command:
+
+```
+ADDENVVAR ENVVAR(SC_TCPSVR_SUBMIT) VALUE('Y') LEVEL(*SYS) REPLACE(*YES)
+```
+
+When STRTCPSVR detects the environment variable having the value 'Y', it will submit a job to start the service instead of starting the service in the job running the STRTCPSVR command, thus shortening the lock time significantly and allow the same command in other jobs to run and not time out.
+
 # Using with ADDJOBSCDE
 
 It may be desired to start, stop, or ensure the liveliness of services on a particular schedule. This is most easily accomplished once the `STRTCPSVR`

--- a/strtcpsvr/sc_tcpsvr.c
+++ b/strtcpsvr/sc_tcpsvr.c
@@ -118,6 +118,9 @@ int main(int argc, char *argv[])
         parm->rc = RC_FAILED;
         return 1;
     }
+
+    // Set flag for submit of SC job.
+
     int is_batch = 1;
 
     struct passwd *pd;
@@ -125,6 +128,17 @@ int main(int argc, char *argv[])
     {
         is_batch = (pd->pw_name[0] == 'Q');
     }
+
+    char* sc_submit = getenv("SC_TCPSVR_SUBMIT");
+    if (NULL == sc_submit)
+    {
+        sc_submit = "";
+    }
+    if (0 == memcmp(sc_submit, "Y", 1))
+    {
+        is_batch = 1;
+    }
+
 #define CMD_MAX 333
     char command[CMD_MAX];
     char command_printf_fmt[CMD_MAX];


### PR DESCRIPTION
This PR is a solution to the problem discussed in issue #108.

Code has been added to check for an environment variable SC_TCPSVR_SUBMIT with the value "Y". If this does exist, the bash command to start sc is submitted to a new job instead of running in the current job. This reduces the lock time significantly and may allow other jobs to run STRTCPSVR without failing.

By using an environment variable the user can control the behavior of STRTCPSVR *SC. If not set, it runs as before. Setting the value to "Y" changes this behavior and issues a SBMJOB.

I coded it this way since I don't know the reasoning for the current behavior where the SBMJOB is only issued for user profiles starting with "Q". It could very well be that I'm missing something and by letting the environment variable control the SBMJOB, my solution can fit all situations.