### PR TITLE
Fix missing delete of README file in SC library

### DIFF
--- a/strtcpsvr/install_sc_tcpsvr
+++ b/strtcpsvr/install_sc_tcpsvr
@@ -7,6 +7,7 @@ SCTGTRLS=${SCTGTRLS:-*CURRENT}
 /QOpenSys/usr/bin/system -Kkpiebv "DLTMOD MODULE(${SCTARGET}/SC)" || echo "module doesn't exist yet"
 /QOpenSys/usr/bin/system -Kkpiebv "DLTPGM PGM(${SCTARGET}/SC)" || echo "program doesn't exist yet"
 /QOpenSys/usr/bin/system -Kkpiebv "RMVTCPSVR SVRSPCVAL(*SC)" || echo "TCPSVR doesn't exist yet"
+/QOpenSys/usr/bin/system -Kkpiebv "DLTF FILE(${SCTARGET}/README)" || echo "README doesn't exist yet"
 
 set -e
 DIR=$(/QOpenSys/pkgs/bin/readlink -f $(dirname $0))

--- a/strtcpsvr/remove_sc_tcpsvr
+++ b/strtcpsvr/remove_sc_tcpsvr
@@ -7,6 +7,7 @@ then
   exit 1
 fi
 
+/QOpenSys/usr/bin/system -Kkpiebv "DLTF FILE(${SCTARGET}/README)" || echo "README doesn't exist"
 /QOpenSys/usr/bin/system -Kkpiebv "RMVTCPSVR SVRSPCVAL(*SC)" || echo "TCPSVR has not been installed"
 /QOpenSys/usr/bin/system -Kkpiebv "DLTMOD MODULE(${SCTARGET}/SC)" || echo "module doesn't exist"
 /QOpenSys/usr/bin/system -Kkpiebv "DLTPGM PGM(${SCTARGET}/SC)" || echo "program doesn't exist"


### PR DESCRIPTION
## Explain the reasoning for this pull request. For instance, is it for a new feature, bug fix, code style/cleanup, or something else? If fixing an open issue, please link to it here.

The README file were not deleted in the install and remove script.

When re-running the install script, no SUCCESS message was shown since the create of README failed.
This has now been fixed.
