### PR TITLE
print help if no non-dashed args

### DIFF
--- a/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
+++ b/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
@@ -179,7 +179,9 @@ public class ServiceCommander {
                 nonDashedArgs.add(remainingArg);
             }
         }
-
+        if(nonDashedArgs.isEmpty()) {
+            printUsageAndExit();
+        }
         final String operation = nonDashedArgs.removeFirst().trim();
 
         if (0 == nonDashedArgs.size() && (operation.equalsIgnoreCase("check") || operation.equalsIgnoreCase("list") || operation.equalsIgnoreCase("status"))) {


### PR DESCRIPTION
If you were to run `sc` without any non-dashed args (for instance `sc -v`), this change prints out the help text