### PR TITLE
Overview of all groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Usage: sc  [options] <operation> <service>
         perfinfo: print basic performance info about the service
         loginfo: get log file info for the service (best guess only)
         list: print service short name and friendly name
+        groups: print an overview of all groups
 
     Valid formats of the <service(s)> specifier include:
         - the short name of a configured service
@@ -246,6 +247,17 @@ See what ports are currently listening
 
 ```
 scopenports
+```
+
+List all groups
+
+```
+sc groups
+```
+
+Only list groups that are defined within the users private YAML configuration files
+```
+sc groups --ignore-globals
 ```
 
 ## Checking which ports are currently open

--- a/man/sc.md
+++ b/man/sc.md
@@ -215,6 +215,7 @@ Usage: sc  [options] <operation> <service>
         perfinfo: print basic performance info about the service
         loginfo: get log file info for the service (best guess only)
         list: print service short name and friendly name
+        groups: print an overview of all groups
 
     Valid formats of the <service(s)> specifier include:
         - the short name of a configured service

--- a/src/main/java/jesseg/ibmi/opensource/OperationExecutor.java
+++ b/src/main/java/jesseg/ibmi/opensource/OperationExecutor.java
@@ -35,7 +35,7 @@ import jesseg.ibmi.opensource.utils.SbmJobScript;
 public class OperationExecutor {
 
     public enum Operation {
-        CHECK(false), FILE(false), INFO(false), JOBINFO(false), LIST(false), LOGINFO(false), PERFINFO(false), RESTART(true), START(true), STOP(true);
+        CHECK(false), FILE(false), INFO(false), JOBINFO(false), LIST(false), LOGINFO(false), PERFINFO(false), RESTART(true), START(true), STOP(true), GROUPS(false);
         public static Operation valueOfWithAliasing(final String _opStr) {
             final String lookupStr = _opStr.trim().toUpperCase();
             if (lookupStr.equals("STATUS")) {

--- a/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
+++ b/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
@@ -211,6 +211,7 @@ public class ServiceCommander {
         }
         final String operation = nonDashedArgs.removeFirst().trim();
 
+        // TODO: push this attributes into the `Operation` enum
         if (0 == nonDashedArgs.size() && (operation.equalsIgnoreCase("check") || operation.equalsIgnoreCase("list") || operation.equalsIgnoreCase("status") || operation.equalsIgnoreCase("groups"))) {
             nonDashedArgs.add("group:all");
         }

--- a/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
+++ b/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Stack;
+import java.util.TreeSet;
 
 import com.github.theprez.jcmdutils.AppLogger;
 import com.github.theprez.jcmdutils.AppLogger.DeferredLogger;
@@ -125,23 +126,15 @@ public class ServiceCommander {
     }
     
     public static void listServiceGroups(ServiceDefinitionCollection serviceDefs, boolean isIgnoreGlobals, AppLogger logger) throws SCException {
-    	LinkedList<String> groups = new LinkedList<>();
+    	TreeSet<String> groups = new TreeSet<String>();
     	if (!isIgnoreGlobals) {
     		groups.add("system");
     	}
     	for (ServiceDefinition serviceDefinition : serviceDefs.getServices()) {
     		for (String serviceGroup : serviceDefinition.getGroups()) {
-    			if (!groups.contains(serviceGroup)) {
-    				groups.add(serviceGroup);
-    			}
+    			groups.add(serviceGroup);
     		}
     	}
-    	groups.sort(new Comparator<String>() {
-    		@Override
-    		public int compare(String s1, String s2) {
-    			return Collator.getInstance().compare(s1, s2);
-    		}
-    	});
     	for (String group : groups) {
     		logger.println(group);
     	}


### PR DESCRIPTION
This pull request references feature request #123. It enables the user to list all groups that are either defined within YAML configuration files or are predefined, such as the group "system". With the argument "--ignore-globals", only groups are shown that are defined within the users private YAML configuration files.


`sc groups [--ignore-globals]`
