### PR TITLE
Update services using check_alive_criteria

### DIFF
--- a/samples/crond.yaml
+++ b/samples/crond.yaml
@@ -1,9 +1,8 @@
 name: Cron daemon
 start_cmd: /QOpenSys/pkgs/bin/crond -n
 
-check_alive: jobname 
-check_alive_criteria: crond
+check_alive: CROND
 
 batch_mode: yes
-sbmjob_jobname: crond
+sbmjob_jobname: CROND
 sbmjob_opts: JOBQ(QUSRNOMAX)

--- a/samples/host_servers/system_as-svrmap.yaml
+++ b/samples/host_servers/system_as-svrmap.yaml
@@ -2,8 +2,7 @@ name: System *SVRMAP Host Server
 start_cmd: system 'strhostsvr *SVRMAP'
 stop_cmd: system 'endhostsvr *SVRMAP'
 
-check_alive: port
-check_alive_criteria: 449
+check_alive: 449
 
 groups:
   - "host_servers"

--- a/samples/kafka.yaml
+++ b/samples/kafka.yaml
@@ -3,8 +3,7 @@ dir: /home/JGORZINS/mykafka/kafka_2.13-2.6.0/config
 start_cmd: ../bin/kafka-server-start.sh server.properties
 stop_cmd: ../bin/kafka-server-stop.sh server.properties
 
-check_alive: port
-check_alive_criteria: 9092
+check_alive: 9092
 
 batch_mode: no
 sbmjob_jobname: Kafka

--- a/samples/mariadb.yaml
+++ b/samples/mariadb.yaml
@@ -1,5 +1,4 @@
 name: MariaDB Server
 start_cmd: /QOpenSys/pkgs/bin/mysqld_safe --datadir=/QOpenSys/var/lib/mariadb/data
 
-check_alive: port
-check_alive_criteria: 3306
+check_alive: 3306

--- a/samples/system_tcpsvr/system_ftp.yaml
+++ b/samples/system_tcpsvr/system_ftp.yaml
@@ -2,8 +2,7 @@ name: System FTP server
 start_cmd: system 'strtcpsvr *FTP'
 stop_cmd: system 'endtcpsvr *FTP'
 
-check_alive: port
-check_alive_criteria: 21
+check_alive: 21
 
 groups:
   - "tcp_servers"

--- a/samples/system_tcpsvr/system_netserver.yaml
+++ b/samples/system_tcpsvr/system_netserver.yaml
@@ -2,8 +2,6 @@ name: System NetServer
 start_cmd: system 'STRTCPSVR SERVER(*NETSVR)'
 stop_cmd: system 'ENDTCPSVR SERVER(*NETSVR)'
 
-# Note: Until ServiceCommander support multiple ports
-# we are just checking the CIFS port 445.
 check_alive: 445,137,139
 
 groups:

--- a/samples/system_tcpsvr/system_smtp.yaml
+++ b/samples/system_tcpsvr/system_smtp.yaml
@@ -2,7 +2,7 @@ name: System SMTP server
 start_cmd: system 'STRTCPSVR SERVER(*SMTP)'
 stop_cmd: system 'ENDTCPSVR SERVER(*SMTP)'
 
-check_alive: port:25
+check_alive: 25
 
 groups:
   - "tcp_servers"

--- a/samples/system_tcpsvr/system_sshd.yaml
+++ b/samples/system_tcpsvr/system_sshd.yaml
@@ -2,8 +2,7 @@ name: System Secure Shell server
 start_cmd: system 'STRTCPSVR SERVER(*SSHD)'
 stop_cmd: system 'ENDTCPSVR SERVER(*SSHD)'
 
-check_alive: port
-check_alive_criteria: 22
+check_alive: 22
 
 groups:
   - "tcp_servers"

--- a/samples/zookeeper.yaml
+++ b/samples/zookeeper.yaml
@@ -3,8 +3,7 @@ dir: /home/JGORZINS/mykafka/kafka_2.13-2.6.0/config
 start_cmd: ../bin/zookeeper-server-start.sh zookeeper.properties
 stop_cmd: ../bin/zookeeper-server-stop.sh zookeeper.properties
 
-check_alive: jobname
-check_alive_criteria: zookeeper
+check_alive: zookeeper
 
 batch_mode: yes
 sbmjob_jobname: zookeeper


### PR DESCRIPTION
## Explain the reasoning for this pull request. For instance, is it for a new feature, bug fix, code style/cleanup, or something else? If fixing an open issue, please link to it here.

This PR updates the default service configurations that still used the `check_alive_criteria` field, so they now will only use the correct field `check_alive`.

## Any additional comments/context?
