### PR TITLE
Make sc_install_defaults exit gracefully when no IWS server is found

### DIFF
--- a/scripts/sc_install_defaults
+++ b/scripts/sc_install_defaults
@@ -176,7 +176,10 @@ fi
 
 if [ "1" == "$DO_IWS" ]; then
     for i in $(qsh -c "JAVA_TOOL_OPTIONS=-Dos400.stdio.convert=N /qibm/proddata/os/webservices/bin/listWebServicesServers.sh |cut -d' ' -f1"); do
-        install_iws $i
+        if [ "IWS00105I" != "$i" ];
+        then
+            install_iws $i
+        fi
     done
 fi
 


### PR DESCRIPTION
## Explain the reasoning for this pull request. For instance, is it for a new feature, bug fix, code style/cleanup, or something else? If fixing an open issue, please link to it here.

Fixing issue #171 

## Any additional comments/context?
