### PR TITLE
Bugfix: Check if temporary directory for logs already exists

### DIFF
--- a/src/main/java/jesseg/ibmi/opensource/AppDirectories.java
+++ b/src/main/java/jesseg/ibmi/opensource/AppDirectories.java
@@ -61,8 +61,10 @@ public enum AppDirectories {
         }
         final File tmpLogsDir = new File(System.getProperty("java.io.tmpdir", "/tmp") + "/.sc_logs_" + _user.trim().toLowerCase());
         _logger.printfln_verbose("Using temporary directory '%s' for logs for user '%s'", tmpLogsDir.getAbsolutePath(), _user);
-        if (!tmpLogsDir.mkdir()) {
-            throw new SCException(_logger, FailureType.GENERAL_ERROR, "ERROR: Unable to create log dir '%s'", tmpLogsDir.getAbsolutePath());
+        if (!tmpLogsDir.isDirectory()) {
+            if (!tmpLogsDir.mkdir()) {
+                throw new SCException(_logger, FailureType.GENERAL_ERROR, "ERROR: Unable to create log dir '%s'", tmpLogsDir.getAbsolutePath());
+            }
         }
         try {
             if (0 != quickExec("/QOpenSys/usr/bin/chown", _user.toLowerCase().trim(), tmpLogsDir.getAbsolutePath())) {


### PR DESCRIPTION
## Explain the reasoning for this pull request. For instance, is it for a new feature, bug fix, code style/cleanup, or something else? If fixing an open issue, please link to it here.

When SC uses a temporary directory in `/tmp` for logs, it creates the directory without checking if it already exists.
So the first run of `sc info <service>` works fine, but the subsequent runs of the same command exits with the following error:
```
Using temporary directory '/tmp/.sc_logs_postgres' for logs for user 'POSTGRES'
ERROR: Unable to create log dir '/tmp/.sc_logs_postgres'
```
(here using the `postgres` service)

This PR fixes this problem by checking for existing directory before creating it.

## Any additional comments/context?
