### PR TITLE
Ignore system group on STRTCPSVR/ENDTCPSVR instance *ALL

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ There are a couple special groups used by the TCP server support. You can define
 
 - `default`, which is what's started or ended if no instance is specified (i.e. `STRTCPSVR SERVER(*SC)`)
 - `autostart`, which is what's started when invoked on the `*AUTOSTART` instance (i.e. `STRTCPSVR SERVER(*SC) INSTANCE(*AUTOSTART)`)
+- `system`, which contains the system services and is used when invoked on anything but the `*ALL` instance. This makes it possible to start or stop a system service using ServiceCommander. E.g. to end the NetServer service, run `ENDTCPSVR SERVER(*SC) INSTANCE('system_netserver')`.
 
 #### Running two or more STRTCPSVR commands simultaneously
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@
     - [Special groups used by STRTCPSVR/ENDTCPSVR](#special-groups-used-by-strtcpsvrendtcpsvr)
     - [Running two or more STRTCPSVR commands simultaneously](#running-two-or-more-strtcpsvr-commands-simultaneously)
     - [Using with ADDJOBSCDE](#using-with-addjobscde)
-    - [Special groups used by STRTCPSVR/ENDTCPSVR](#special-groups-used-by-strtcpsvrendtcpsvr-1)
 - [Demo (video)](#demo-video)
 - [Have feedback or want to contribute?](#have-feedback-or-want-to-contribute)
 - [Testimonials](#testimonials)
@@ -695,13 +694,6 @@ running, every day at 01:00:
 ```cl
 ADDJOBSCDE JOB(SC) CMD(STRTCPSVR SERVER(*SC) INSTANCE('myapp')) FRQ(*WEEKLY) SCDDATE(*NONE) SCDDAY(*ALL) SCDTIME(010000)
 ```
-
-#### Special groups used by STRTCPSVR/ENDTCPSVR
-
-There are a couple special groups used by the TCP server support. You can define your services to be members of one or more of these groups:
-
-- `default`, which is what's started or ended if no instance is specified (i.e. `STRTCPSVR SERVER(*SC)`)
-- `autostart`, which is what's started when invoked on the `*AUTOSTART` instance (i.e. `STRTCPSVR SERVER(*SC) INSTANCE(*AUTOSTART)`)
 
 ## Demo (video)
 

--- a/strtcpsvr/sc_tcpsvr.c
+++ b/strtcpsvr/sc_tcpsvr.c
@@ -194,6 +194,8 @@ int main(int argc, char *argv[])
         instance[i] = tolower(instance[i]);
     }
     int is_ipl = FALSE;
+    char sc_all[3];
+    strcpy(sc_all, "-a");
 #define ISINSTANCE(name) (instance_len == sizeof(name) - 1 && memcmp(parm->instance, name, instance_len) == 0)
     if (ISINSTANCE("*DFT"))
     {
@@ -202,6 +204,7 @@ int main(int argc, char *argv[])
     else if (ISINSTANCE("*ALL"))
     {
         strcpy(instance, "group:all");
+        strcpy(sc_all, "");
     }
     else if (ISINSTANCE("*AUTOSTART"))
     {
@@ -270,7 +273,7 @@ int main(int argc, char *argv[])
     child_argv[2] = "-l";
     child_argv[3] = "-c";
     char sc_cmd[1024];
-    snprintf(sc_cmd, sizeof(sc_cmd), "exec /QOpenSys/pkgs/bin/sc -a %s %s %s 2>&1", sc_options, sc_operation, instance);
+    snprintf(sc_cmd, sizeof(sc_cmd), "exec /QOpenSys/pkgs/bin/sc %s %s %s %s 2>&1", sc_all, sc_options, sc_operation, instance);
     child_argv[4] = sc_cmd;
     child_argv[5] = NULL;
 


### PR DESCRIPTION
The ENDTCP command will perform ENDTCPSVR *ALL and if option '-a' is in use,
all services in SC group 'system' will also be ended - including system_as-sts,
which will cause error "Unable to determine job".

Also the services in group 'system' are being ended by their own exit program,
so no need for SC to do this as well.

## Explain the reasoning for this pull request. For instance, is it for a new feature, bug fix, code style/cleanup, or something else? If fixing an open issue, please link to it here.

This PR will fix #174 

## Any additional comments/context?
