### PR TITLE
Feature/config colors branch fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .classpath
 /bin/
 /src/main/java/jesseg/ibmi/opensource/Version.java
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ install: scripts/sc scripts/scinit scripts/sc_install_defaults target/sc.jar tar
 	install -m 444 -o qsys target/sc.jar ${INSTALL_ROOT}/QOpenSys/pkgs/lib/sc/sc.jar
 	install -m 555 -o qsys target/scbash ${INSTALL_ROOT}/QOpenSys/pkgs/lib/sc/native/scbash
 	install -m 555 -o qsys target/screbash ${INSTALL_ROOT}/QOpenSys/pkgs/lib/sc/native/screbash
+	dos2unix ${INSTALL_ROOT}/QOpenSys/pkgs/bin/sc
 	cp -n samples/system_tcpsvr/* ${INSTALL_ROOT}/QOpenSys/etc/sc/services/system
 	cp -n samples/system_common/* ${INSTALL_ROOT}/QOpenSys/etc/sc/services/system
 	cp -n samples/host_servers/* ${INSTALL_ROOT}/QOpenSys/etc/sc/services/system

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ install: scripts/sc scripts/scinit scripts/sc_install_defaults target/sc.jar tar
 	install -m 444 -o qsys target/sc.jar ${INSTALL_ROOT}/QOpenSys/pkgs/lib/sc/sc.jar
 	install -m 555 -o qsys target/scbash ${INSTALL_ROOT}/QOpenSys/pkgs/lib/sc/native/scbash
 	install -m 555 -o qsys target/screbash ${INSTALL_ROOT}/QOpenSys/pkgs/lib/sc/native/screbash
-	dos2unix ${INSTALL_ROOT}/QOpenSys/pkgs/bin/sc
 	cp -n samples/system_tcpsvr/* ${INSTALL_ROOT}/QOpenSys/etc/sc/services/system
 	cp -n samples/system_common/* ${INSTALL_ROOT}/QOpenSys/etc/sc/services/system
 	cp -n samples/host_servers/* ${INSTALL_ROOT}/QOpenSys/etc/sc/services/system

--- a/conf/scrc
+++ b/conf/scrc
@@ -9,3 +9,21 @@
 # profiling time when gathering performance info:
 #
 # --sampletime=10
+#
+# ---- Customize Terminal Colors ----
+#
+# Terminal Color defaults used in sc:
+#   RUNNING: GREEN
+#   NOT_RUNNING: PURPLE
+#   INFO: CYAN
+#   WARNING: YELLOW
+#   ERROR: BRIGHT_RED
+#   PLAIN: WHITE
+#   STATUS: BLUE
+#
+# To override these colors, uncomment the following and
+# add comma separated list of contexts and colors to change:
+#
+# --color-scheme=[CONTEXT:COLOR], [CONTEXT:COLOR]
+#
+# ex. --color-scheme=RUNNING:BLUE, INFO=PURPLE

--- a/conf/scrc
+++ b/conf/scrc
@@ -10,9 +10,19 @@
 #
 # --sampletime=10
 #
-# ---- Customize Terminal Colors ----
+# ---------------- Customize Terminal Colors  ----------------
 #
-# Terminal Color defaults used in sc:
+# Here is a list of available colors for customization:
+#   - BLUE
+#   - BRIGHT_RED
+#   - CYAN
+#   - GREEN
+#   - PURPLE
+#   - RED
+#   - WHITE
+#   - YELLOW
+#
+# Terminal Color defaults and contexts used in sc:
 #   RUNNING: GREEN
 #   NOT_RUNNING: PURPLE
 #   INFO: CYAN

--- a/src/main/java/jesseg/ibmi/opensource/OperationExecutor.java
+++ b/src/main/java/jesseg/ibmi/opensource/OperationExecutor.java
@@ -39,6 +39,8 @@ import jesseg.ibmi.opensource.utils.ProcessLauncher;
 import jesseg.ibmi.opensource.utils.QueryUtils;
 import jesseg.ibmi.opensource.utils.QueryUtils.DspJobDottedAttr;
 import jesseg.ibmi.opensource.utils.SbmJobScript;
+import jesseg.ibmi.opensource.utils.ColorSchemeConfig.ColorScheme;
+import jesseg.ibmi.opensource.utils.ColorSchemeConfig;
 
 /**
  * Where all the work happens
@@ -211,7 +213,7 @@ public class OperationExecutor {
                     printServiceStatus();
                     return null;
                 case LIST:
-                    m_logger.printf("%s (%s)\n", StringUtils.colorizeForTerminal(m_mainService.getName(), TerminalColor.CYAN), m_mainService.getFriendlyName());
+                    m_logger.printf("%s (%s)\n", StringUtils.colorizeForTerminal(m_mainService.getName(), ColorSchemeConfig.get("INFO")), m_mainService.getFriendlyName());
                     return null;
                 case INFO:
                     printInfo();
@@ -246,7 +248,7 @@ public class OperationExecutor {
         } finally {
             if (null != logFile) {
                 if (0 < logFile.length()) {
-                    m_logger.println("For details, see log file at: " + StringUtils.colorizeForTerminal(logFile.getAbsolutePath(), TerminalColor.CYAN));
+                    m_logger.println("For details, see log file at: " + StringUtils.colorizeForTerminal(logFile.getAbsolutePath(), ColorSchemeConfig.get("INFO")));
                 }
             }
         }
@@ -516,55 +518,55 @@ public class OperationExecutor {
     private void printInfo() {
         m_logger.println();
         m_logger.println();
-        m_logger.println(StringUtils.colorizeForTerminal("---------------------------------------------------------------------", TerminalColor.WHITE));
-        m_logger.println(StringUtils.colorizeForTerminal(m_mainService.getName(), TerminalColor.CYAN) + " (" + m_mainService.getFriendlyName() + ")");
+        m_logger.println(StringUtils.colorizeForTerminal("---------------------------------------------------------------------", ColorSchemeConfig.get("PLAIN")));
+        m_logger.println(StringUtils.colorizeForTerminal(m_mainService.getName(), ColorSchemeConfig.get("INFO")) + " (" + m_mainService.getFriendlyName() + ")");
         m_logger.println();
         m_logger.println();
-        m_logger.println(StringUtils.colorizeForTerminal("Defined in: ", TerminalColor.CYAN) + m_mainService.getSource());
+        m_logger.println(StringUtils.colorizeForTerminal("Defined in: ", ColorSchemeConfig.get("INFO")) + m_mainService.getSource());
         m_logger.println();
         final String dir = m_mainService.getConfiguredWorkingDirectory();
         if (!StringUtils.isEmpty(dir)) {
-            m_logger.println(StringUtils.colorizeForTerminal("Working Directory: ", TerminalColor.CYAN) + dir);
+            m_logger.println(StringUtils.colorizeForTerminal("Working Directory: ", ColorSchemeConfig.get("INFO")) + dir);
             m_logger.println();
         }
-        m_logger.println(StringUtils.colorizeForTerminal("Startup Command: ", TerminalColor.CYAN) + m_mainService.getStartCommand());
-        m_logger.println(StringUtils.colorizeForTerminal("Startup Wait Time (s): ", TerminalColor.CYAN) + m_mainService.getStartupWaitTime());
+        m_logger.println(StringUtils.colorizeForTerminal("Startup Command: ", ColorSchemeConfig.get("INFO")) + m_mainService.getStartCommand());
+        m_logger.println(StringUtils.colorizeForTerminal("Startup Wait Time (s): ", ColorSchemeConfig.get("INFO")) + m_mainService.getStartupWaitTime());
         m_logger.println();
         final String shutdownCommand = m_mainService.getStopCommand();
         if (!StringUtils.isEmpty(shutdownCommand)) {
-            m_logger.println(StringUtils.colorizeForTerminal("Shutdown Command: ", TerminalColor.CYAN) + shutdownCommand);
+            m_logger.println(StringUtils.colorizeForTerminal("Shutdown Command: ", ColorSchemeConfig.get("INFO")) + shutdownCommand);
         }
-        m_logger.println(StringUtils.colorizeForTerminal("Shutdown Wait Time (s): ", TerminalColor.CYAN) + m_mainService.getShutdownWaitTime());
+        m_logger.println(StringUtils.colorizeForTerminal("Shutdown Wait Time (s): ", ColorSchemeConfig.get("INFO")) + m_mainService.getShutdownWaitTime());
         m_logger.println();
-        m_logger.println(StringUtils.colorizeForTerminal("Check-alive conditions: ", TerminalColor.CYAN) + m_mainService.getCheckAlivesHumanReadable());
+        m_logger.println(StringUtils.colorizeForTerminal("Check-alive conditions: ", ColorSchemeConfig.get("INFO")) + m_mainService.getCheckAlivesHumanReadable());
         final BatchMode batchMode = m_mainService.getBatchMode();
         if (BatchMode.NO_BATCH == batchMode) {
-            m_logger.println(StringUtils.colorizeForTerminal("Batch Mode: ", TerminalColor.CYAN) + "<not running in batch>");
+            m_logger.println(StringUtils.colorizeForTerminal("Batch Mode: ", ColorSchemeConfig.get("INFO")) + "<not running in batch>");
         } else {
-            m_logger.println(StringUtils.colorizeForTerminal("Batch Mode: ", TerminalColor.CYAN) + "<submitted to batch>");
+            m_logger.println(StringUtils.colorizeForTerminal("Batch Mode: ", ColorSchemeConfig.get("INFO")) + "<submitted to batch>");
             String batchJobName = m_mainService.getBatchJobName();
             if (StringUtils.isEmpty(batchJobName)) {
                 batchJobName = "<default>";
             }
-            m_logger.println(StringUtils.colorizeForTerminal("    Batch Job Name: ", TerminalColor.CYAN) + batchJobName);
+            m_logger.println(StringUtils.colorizeForTerminal("    Batch Job Name: ", ColorSchemeConfig.get("INFO")) + batchJobName);
             final String sbmjobOpts = m_mainService.getSbmJobOpts();
             if (!StringUtils.isEmpty(sbmjobOpts)) {
-                m_logger.println(StringUtils.colorizeForTerminal("    SBMJOB options: ", TerminalColor.CYAN) + sbmjobOpts);
+                m_logger.println(StringUtils.colorizeForTerminal("    SBMJOB options: ", ColorSchemeConfig.get("INFO")) + sbmjobOpts);
             }
         }
         final List<String> dependencies = m_mainService.getDependencies();
         if (!dependencies.isEmpty()) {
             m_logger.println();
-            m_logger.println(StringUtils.colorizeForTerminal("Depends on the following services:", TerminalColor.CYAN));
+            m_logger.println(StringUtils.colorizeForTerminal("Depends on the following services:", ColorSchemeConfig.get("INFO")));
             for (final String dependency : dependencies) {
                 m_logger.println("    " + dependency);
             }
         }
         m_logger.println();
-        m_logger.println(StringUtils.colorizeForTerminal("Inherits environment variables?: ", TerminalColor.CYAN) + m_mainService.isInheritingEnvironmentVars());
+        m_logger.println(StringUtils.colorizeForTerminal("Inherits environment variables?: ", ColorSchemeConfig.get("INFO")) + m_mainService.isInheritingEnvironmentVars());
         final List<String> envVars = m_mainService.getEnvironmentVars();
         if (!envVars.isEmpty()) {
-            m_logger.println(StringUtils.colorizeForTerminal("Custom environment variables:", TerminalColor.CYAN));
+            m_logger.println(StringUtils.colorizeForTerminal("Custom environment variables:", ColorSchemeConfig.get("INFO")));
             for (final String envVar : envVars) {
                 m_logger.println("    " + envVar);
             }
@@ -575,10 +577,10 @@ public class OperationExecutor {
     }
 
     private void printJobInfo() throws SCException, IOException {
-        m_logger.println(StringUtils.colorizeForTerminal(m_mainService.getName(), TerminalColor.CYAN) + " (" + m_mainService.getFriendlyName() + "):");
+        m_logger.println(StringUtils.colorizeForTerminal(m_mainService.getName(), ColorSchemeConfig.get("INFO")) + " (" + m_mainService.getFriendlyName() + "):");
         final List<String> jobs = getActiveJobsForService(false);
         if (jobs.isEmpty()) {
-            m_logger.println("    " + StringUtils.colorizeForTerminal("NO JOB INFO (either not running, or running in kernel task)", TerminalColor.PURPLE));
+            m_logger.println("    " + StringUtils.colorizeForTerminal("NO JOB INFO (either not running, or running in kernel task)", ColorSchemeConfig.get("NOT_RUNNING")));
         } else {
             for (final String job : jobs) {
                 m_logger.println("    " + job);
@@ -609,7 +611,7 @@ public class OperationExecutor {
         for (final String job : jobs) {
             try {
                 for (final String splf : QueryUtils.getSplfsForJob(job, m_logger)) {
-                    m_logger.println(m_mainService.getName() + ": " + StringUtils.colorizeForTerminal(splf, TerminalColor.CYAN));
+                    m_logger.println(m_mainService.getName() + ": " + StringUtils.colorizeForTerminal(splf, ColorSchemeConfig.get("INFO")));
                     isAnythingFound = true;
                 }
             } catch (final Exception e) {
@@ -633,10 +635,10 @@ public class OperationExecutor {
 
             final File logFile = new File(candidate);
             if (0 < logFile.length()) {
-                m_logger.println(m_mainService.getName() + ": " + StringUtils.colorizeForTerminal(candidate, TerminalColor.CYAN));
+                m_logger.println(m_mainService.getName() + ": " + StringUtils.colorizeForTerminal(candidate, ColorSchemeConfig.get("INFO")));
                 isAnythingFound = true;
             } else {
-                m_logger.println(m_mainService.getName() + ": " + StringUtils.colorizeForTerminal(candidate, TerminalColor.CYAN) + StringUtils.colorizeForTerminal(" (no data)", TerminalColor.YELLOW));
+                m_logger.println(m_mainService.getName() + ": " + StringUtils.colorizeForTerminal(candidate, ColorSchemeConfig.get("INFO")) + StringUtils.colorizeForTerminal(" (no data)", ColorSchemeConfig.get("WARNING")));
             }
         }
         if (!isAnythingFound) {
@@ -648,12 +650,12 @@ public class OperationExecutor {
 
     private void printPerfInfo() throws SCException, IOException {
         m_logger.println();
-        m_logger.println(StringUtils.colorizeForTerminal("---------------------------------------------------------------------", TerminalColor.WHITE));
+        m_logger.println(StringUtils.colorizeForTerminal("---------------------------------------------------------------------", ColorSchemeConfig.get("PLAIN")));
 
-        m_logger.println(StringUtils.colorizeForTerminal(m_mainService.getName(), TerminalColor.CYAN) + " (" + m_mainService.getFriendlyName() + ")");
+        m_logger.println(StringUtils.colorizeForTerminal(m_mainService.getName(), ColorSchemeConfig.get("INFO")) + " (" + m_mainService.getFriendlyName() + ")");
         final List<String> jobs = getActiveJobsForService(false);
         if (jobs.isEmpty()) {
-            m_logger.println(StringUtils.colorizeForTerminal("NOT RUNNING", TerminalColor.PURPLE));
+            m_logger.println(StringUtils.colorizeForTerminal("NOT RUNNING", ColorSchemeConfig.get("NOT_RUNNING")));
         } else {
             m_logger.println();
             final List<PerfInfoFetcher> dataFetcherThreads = new LinkedList<PerfInfoFetcher>();
@@ -664,10 +666,10 @@ public class OperationExecutor {
                 dataFetcherThreads.add(new PerfInfoFetcher(job, "Backend job", m_logger, Float.parseFloat(System.getProperty(PROP_SAMPLE_TIME, "1.0"))));
             }
             for (final PerfInfoFetcher dataFetcherThread : dataFetcherThreads) {
-                m_logger.println(StringUtils.colorizeForTerminal(dataFetcherThread.m_eyecatcher + ": " + dataFetcherThread.m_job, TerminalColor.CYAN));
+                m_logger.println(StringUtils.colorizeForTerminal(dataFetcherThread.m_eyecatcher + ": " + dataFetcherThread.m_job, ColorSchemeConfig.get("INFO")));
                 final Map<String, String> perfInfo = dataFetcherThread.getResults();
                 for (final Entry<String, String> pi : perfInfo.entrySet()) {
-                    m_logger.println("    " + StringUtils.colorizeForTerminal(pi.getKey(), TerminalColor.CYAN) + ": " + pi.getValue());
+                    m_logger.println("    " + StringUtils.colorizeForTerminal(pi.getKey(), ColorSchemeConfig.get("INFO")) + ": " + pi.getValue());
                 }
                 m_logger.println();
             }
@@ -691,7 +693,7 @@ public class OperationExecutor {
         }
         for (final String job : jobs) {
             final Map<String, String> envMap = QueryUtils.getJobEnvvars(job, m_logger);
-            m_logger.println(StringUtils.colorizeForTerminal(m_mainService.getName() + ": " + job + ":", TerminalColor.CYAN));
+            m_logger.println(StringUtils.colorizeForTerminal(m_mainService.getName() + ": " + job + ":", ColorSchemeConfig.get("INFO")));
             boolean isAnyFound = false;
             for (final Entry<String, String> l : envMap.entrySet()) {
                 if (l.getKey().startsWith("SCOMMANDER_")) {
@@ -709,23 +711,23 @@ public class OperationExecutor {
         final ServiceStatusInfo status = getServiceStatus();
         final String paddedStatusString;
         final String indent = m_mainService.isClusterBackend() ? "  " : "";
-        TerminalColor statusColor = TerminalColor.BLUE;
+        TerminalColor statusColor = ColorSchemeConfig.get("STATUS");
         final int statusPadSize = 18;
         switch (status.getStatus()) {
             case RUNNING:
-                paddedStatusString = StringUtils.colorizeForTerminal(StringUtils.spacePad(indent + "RUNNING", statusPadSize), statusColor = TerminalColor.GREEN);
+                paddedStatusString = StringUtils.colorizeForTerminal(StringUtils.spacePad(indent + "RUNNING", statusPadSize), statusColor = ColorSchemeConfig.get("RUNNING"));
                 break;
             case NOT_RUNNING:
-                paddedStatusString = StringUtils.colorizeForTerminal(StringUtils.spacePad(indent + "NOT RUNNING", statusPadSize), statusColor = TerminalColor.PURPLE);
+                paddedStatusString = StringUtils.colorizeForTerminal(StringUtils.spacePad(indent + "NOT RUNNING", statusPadSize), statusColor = ColorSchemeConfig.get("NOT_RUNNING"));
                 break;
             default:
                 final String statusString = String.format("" + indent + "PARTIAL (%d/%d)", status.m_runningList.size(), status.m_allList.size());
-                paddedStatusString = StringUtils.colorizeForTerminal(StringUtils.spacePad(statusString, statusPadSize), statusColor = TerminalColor.YELLOW);
+                paddedStatusString = StringUtils.colorizeForTerminal(StringUtils.spacePad(statusString, statusPadSize), statusColor = ColorSchemeConfig.get("WARNING"));
                 break;
         }
         String partialInfo = "";
         if (status.isPartial()) {
-            partialInfo += StringUtils.colorizeForTerminal("[not running at -->" + ListUtils.toString(status.m_notRunningList, ", ") + "]", TerminalColor.YELLOW);
+            partialInfo += StringUtils.colorizeForTerminal("[not running at -->" + ListUtils.toString(status.m_notRunningList, ", ") + "]", ColorSchemeConfig.get("WARNING"));
         }
         m_logger.printfln("  %s | %s%s (%s) %s", paddedStatusString, indent, StringUtils.colorizeForTerminal(m_mainService.getName(), statusColor), m_mainService.getFriendlyName(), partialInfo);
     }

--- a/src/main/java/jesseg/ibmi/opensource/OperationExecutor.java
+++ b/src/main/java/jesseg/ibmi/opensource/OperationExecutor.java
@@ -571,7 +571,7 @@ public class OperationExecutor {
                 m_logger.println("    " + envVar);
             }
         }
-        m_logger.println("---------------------------------------------------------------------");
+        m_logger.println(StringUtils.colorizeForTerminal("---------------------------------------------------------------------", ColorSchemeConfig.get("PLAIN")));
         m_logger.println();
         m_logger.println();
     }
@@ -674,7 +674,7 @@ public class OperationExecutor {
                 m_logger.println();
             }
         }
-        m_logger.println("---------------------------------------------------------------------");
+        m_logger.println(StringUtils.colorizeForTerminal("---------------------------------------------------------------------", ColorSchemeConfig.get("PLAIN")));
         m_logger.println();
     }
 

--- a/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
+++ b/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
@@ -18,7 +18,9 @@ import com.github.theprez.jcmdutils.StringUtils.TerminalColor;
 import jesseg.ibmi.opensource.OperationExecutor.Operation;
 import jesseg.ibmi.opensource.SCException.FailureType;
 import jesseg.ibmi.opensource.ServiceDefinition.CheckAliveType;
+import jesseg.ibmi.opensource.utils.ColorSchemeConfig;
 import jesseg.ibmi.opensource.utils.QueryUtils;
+import jesseg.ibmi.opensource.utils.ColorSchemeConfig.ColorScheme;
 import jesseg.ibmi.opensource.yaml.YamlServiceDef;
 import jesseg.ibmi.opensource.yaml.YamlServiceDefLoader;
 
@@ -137,9 +139,9 @@ public class ServiceCommander {
                 line += StringUtils.spacePad("" + port, 8);
                 line += svcDef.isClusterBackend() ? "  " : "";
                 if (svcDef.isAdHoc()) {
-                    line += StringUtils.colorizeForTerminal("port:" + port, TerminalColor.CYAN);
+                    line += StringUtils.colorizeForTerminal("port:" + port, ColorSchemeConfig.get("INFO"));
                 } else {
-                    line += StringUtils.colorizeForTerminal(svcDef.getName(), TerminalColor.CYAN);
+                    line += StringUtils.colorizeForTerminal(svcDef.getName(), ColorSchemeConfig.get("INFO"));
                     line += " (" + svcDef.getFriendlyName() + ")";
                 }
                 _logger.println(line);
@@ -231,6 +233,20 @@ public class ServiceCommander {
                 } catch (final Exception e) {
                     logger.printfln_warn("WARNING: Value specified for sample time argument is not valid: %s", remainingArg);
                 }
+            } else if (remainingArg.startsWith("--color-scheme=")) {
+                String colorSettings[] = remainingArg.replaceAll(".*=", "").split("\\s*, \\s*");
+                for (String kv : colorSettings) {
+                    try {
+                        String[] _settings = kv.split(":");
+                        String context = _settings[0];
+                        String color = _settings[1];
+                        ColorSchemeConfig.updateColor(context, color);
+                    } catch (Exception e) {
+                        logger.printf_warn("WARNING: something went wrong with color-scheme configuration: %s", remainingArg);
+                    }
+                }
+
+
             } else if (remainingArg.startsWith("-")) {
                 logger.printfln_warn("WARNING: Argument '%s' unrecognized and will be ignored", remainingArg);
             } else {
@@ -376,12 +392,12 @@ public class ServiceCommander {
         final String version = jesseg.ibmi.opensource.Version.s_scVersion;
         final String buildTime = jesseg.ibmi.opensource.Version.s_compileDateTime;
         if (StringUtils.isEmpty(version)) {
-            System.err.println(StringUtils.colorizeForTerminal("ERROR: Unknown version!", TerminalColor.BRIGHT_RED));
+            System.err.println(StringUtils.colorizeForTerminal("ERROR: Unknown version!", ColorSchemeConfig.get("ERROR")));
         } else {
             System.out.println("Version: " + version);
         }
         if (StringUtils.isEmpty(buildTime)) {
-            System.err.println(StringUtils.colorizeForTerminal("ERROR: Unknown build time!", TerminalColor.BRIGHT_RED));
+            System.err.println(StringUtils.colorizeForTerminal("ERROR: Unknown build time!", ColorSchemeConfig.get("ERROR")));
         } else {
             System.out.println("Build time: " + buildTime);
         }

--- a/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
+++ b/src/main/java/jesseg/ibmi/opensource/ServiceCommander.java
@@ -238,8 +238,8 @@ public class ServiceCommander {
                 for (String kv : colorSettings) {
                     try {
                         String[] _settings = kv.split(":");
-                        String context = _settings[0];
-                        String color = _settings[1];
+                        String context = _settings[0].toUpperCase();
+                        String color = _settings[1].toUpperCase();
                         ColorSchemeConfig.updateColor(context, color);
                     } catch (Exception e) {
                         logger.printf_warn("WARNING: something went wrong with color-scheme configuration: %s", remainingArg);

--- a/src/main/java/jesseg/ibmi/opensource/ServiceInit.java
+++ b/src/main/java/jesseg/ibmi/opensource/ServiceInit.java
@@ -19,6 +19,7 @@ import com.github.theprez.jcmdutils.StringUtils.TerminalColor;
 import jesseg.ibmi.opensource.OperationExecutor.Operation;
 import jesseg.ibmi.opensource.SCException.FailureType;
 import jesseg.ibmi.opensource.yaml.YamlServiceDefLoader;
+import jesseg.ibmi.opensource.utils.ColorSchemeConfig;
 
 public class ServiceInit {
 
@@ -109,7 +110,7 @@ public class ServiceInit {
 
             si.writeToFile(logger);
             final ServiceDefinitionCollection defs = new YamlServiceDefLoader().loadFromYamlFiles(new AppLogger.DeferredLogger(logger), false);
-            logger.println(StringUtils.colorizeForTerminal("\n\nPrinting information about the newly-defined service", TerminalColor.GREEN));
+            logger.println(StringUtils.colorizeForTerminal("\n\nPrinting information about the newly-defined service", ColorSchemeConfig.get("RUNNING")));
             new OperationExecutor(Operation.INFO, si.m_shortName, defs, logger).execute();
             defs.checkForCheckaliveConflicts(logger);
         } catch (final SCException e) {

--- a/src/main/java/jesseg/ibmi/opensource/utils/ColorSchemeConfig.java
+++ b/src/main/java/jesseg/ibmi/opensource/utils/ColorSchemeConfig.java
@@ -1,0 +1,57 @@
+package jesseg.ibmi.opensource.utils;
+
+import java.util.EnumMap;
+
+import com.github.theprez.jcmdutils.StringUtils.TerminalColor;
+
+public class ColorSchemeConfig {
+    public enum ColorScheme {
+        RUNNING, NOT_RUNNING, INFO, WARNING, ERROR, PLAIN, STATUS;
+    }
+
+    public static EnumMap<ColorScheme, TerminalColor> m_colorConfig;
+
+    static {
+        m_colorConfig = new EnumMap<>(ColorScheme.class);
+        m_colorConfig.put(ColorScheme.RUNNING, TerminalColor.GREEN);
+        m_colorConfig.put(ColorScheme.NOT_RUNNING, TerminalColor.PURPLE);
+        m_colorConfig.put(ColorScheme.INFO, TerminalColor.CYAN);
+        m_colorConfig.put(ColorScheme.WARNING, TerminalColor.YELLOW);
+        m_colorConfig.put(ColorScheme.ERROR, TerminalColor.BRIGHT_RED);
+        m_colorConfig.put(ColorScheme.PLAIN, TerminalColor.WHITE);
+        m_colorConfig.put(ColorScheme.STATUS, TerminalColor.BLUE);
+    }
+
+    public ColorSchemeConfig() {}
+
+    public static void updateColor(String _context, String _color) {
+        try {
+            m_colorConfig.put(ColorScheme.valueOf(_context), TerminalColor.valueOf(_color));
+        } catch (IllegalArgumentException e ) {
+            System.out.println(String.format("ERROR: unable to override terminal color defaults. invalid color context or color: [%s:%s]", _context, _color));
+        }
+    }
+
+    public static TerminalColor get(String _context) {
+        return m_colorConfig.get(ColorScheme.valueOf(_context));
+    }
+
+
+
+    
+
+
+
+
+
+    
+
+
+
+
+
+
+
+
+    
+}

--- a/src/main/java/jesseg/ibmi/opensource/utils/ProcessLauncher.java
+++ b/src/main/java/jesseg/ibmi/opensource/utils/ProcessLauncher.java
@@ -72,10 +72,10 @@ public class ProcessLauncher {
          */
         public void prettyPrint() {
             for (final String stdout : m_stdout) {
-                System.out.println(StringUtils.colorizeForTerminal(stdout, TerminalColor.GREEN));
+                System.out.println(StringUtils.colorizeForTerminal(stdout, ColorSchemeConfig.get("SUCCESS")));
             }
             for (final String stderr : m_stderr) {
-                System.out.println(StringUtils.colorizeForTerminal(stderr, TerminalColor.BRIGHT_RED));
+                System.out.println(StringUtils.colorizeForTerminal(stderr, ColorSchemeConfig.get("ERROR")));
             }
         }
 


### PR DESCRIPTION
## Explain the reasoning for this pull request. For instance, is it for a new feature, bug fix, code style/cleanup, or something else? If fixing an open issue, please link to it here.

This PR has the fixed branch with only changes regarding the terminal color configuration. 

solution for suggestion in #190 for configuring terminal colors 



## Any additional comments/context?

To enable custom terminal colors, head to `/QOpenSys/etc/sc/conf` and open `scrc` with your favorite text editor. Add the following argument with a list of contexts and colors to change. 

```
# Terminal Color defaults used in sc:
#   RUNNING: GREEN
#   NOT_RUNNING: PURPLE
#   INFO: CYAN
#   WARNING: YELLOW
#   ERROR: BRIGHT_RED
#   PLAIN: WHITE
#   STATUS: BLUE
#
# To override these colors, uncomment the following and
# add comma separated list of contexts and colors to change:
#
# --color-scheme=[CONTEXT:COLOR], [CONTEXT:COLOR]

--color-scheme=NOT_RUNNING:RED, RUNNING:CYAN

```
![image](https://user-images.githubusercontent.com/50843283/202012068-db34c8e7-5541-49d5-a2c8-63bd4efe9549.png)