### PR TITLE
Feature/sc tail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ install: scripts/sc scripts/scinit scripts/sc_install_defaults target/sc.jar tar
 	install -m 555 -o qsys scripts/sc ${INSTALL_ROOT}/QOpenSys/pkgs/bin/
 	install -m 555 -o qsys scripts/scinit ${INSTALL_ROOT}/QOpenSys/pkgs/bin/
 	install -m 555 -o qsys scripts/scedit ${INSTALL_ROOT}/QOpenSys/pkgs/bin/
+	install -m 555 -o qsys scripts/sctail ${INSTALL_ROOT}/QOpenSys/pkgs/bin/
 	install -m 555 -o qsys scripts/scopenports ${INSTALL_ROOT}/QOpenSys/pkgs/bin/
 	install -m 555 -o qsys scripts/sc_install_defaults ${INSTALL_ROOT}/QOpenSys/pkgs/bin/
 	install -m 444 -o qsys target/sc.jar ${INSTALL_ROOT}/QOpenSys/pkgs/lib/sc/sc.jar

--- a/scripts/sctail
+++ b/scripts/sctail
@@ -1,9 +1,3 @@
 #!/QOpenSys/pkgs/bin/bash
-FILE_NAME=$($(dirname $0)/sc loginfo $1)
-if [ -z "$FILE_NAME" ]
-then
-    >&2 echo "No configuration file found for '$1'"
-    exit 5
-fi
 
-echo "Configuration for '$1' found at $FILE_NAME"
+/QOpenSys/pkgs/bin/sc loginfo $1 | /QOpenSys/pkgs/bin/cut -d ':' -f 2 | /QOpenSys/pkgs/bin/xargs tail -f

--- a/scripts/sctail
+++ b/scripts/sctail
@@ -1,3 +1,45 @@
 #!/QOpenSys/pkgs/bin/bash
 
-/QOpenSys/pkgs/bin/sc loginfo $1 | /QOpenSys/pkgs/bin/cut -d ':' -f 2 | /QOpenSys/pkgs/bin/xargs tail -f
+if (($# == 0)); then
+    echo "usage: sctail [-f|--follow] <service name>"
+    exit 0
+fi
+
+POSITIONAL_ARGS=()
+HELP_MSG=NO
+FOLLOW=NO
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -f|--follow)
+      FOLLOW=YES
+      shift # past argument with no value
+      ;;
+    --help)
+      HELP_MSG=YES
+      shift # past argument with no value
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift # past argument
+      ;;
+  esac
+done
+set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
+
+if [ ${HELP_MSG} == YES ]; then
+	echo "usage: sctail [-f|--follow] <service name>"
+	exit 0
+fi
+
+/QOpenSys/pkgs/bin/sc loginfo $1
+
+if [ ${FOLLOW} == YES ]; then
+    /QOpenSys/pkgs/bin/sc loginfo $1 | /QOpenSys/pkgs/bin/cut -d ':' -f 2 | /QOpenSys/pkgs/bin/xargs tail -f
+else
+    /QOpenSys/pkgs/bin/sc loginfo $1 | /QOpenSys/pkgs/bin/cut -d ':' -f 2 | /QOpenSys/pkgs/bin/xargs tail
+fi

--- a/scripts/sctail
+++ b/scripts/sctail
@@ -1,0 +1,9 @@
+#!/QOpenSys/pkgs/bin/bash
+FILE_NAME=$($(dirname $0)/sc loginfo $1)
+if [ -z "$FILE_NAME" ]
+then
+    >&2 echo "No configuration file found for '$1'"
+    exit 5
+fi
+
+echo "Configuration for '$1' found at $FILE_NAME"


### PR DESCRIPTION
## Explain the reasoning for this pull request. For instance, is it for a new feature, bug fix, code style/cleanup, or something else? If fixing an open issue, please link to it here.

Add wrapper script for getting live tail of current service. Here is an example command line call for getting the tail of a log file:

```
/QOpenSys/pkgs/bin/sc loginfo $1 | /QOpenSys/pkgs/bin/cut -d ':' -f 2 | /QOpenSys/pkgs/bin/xargs tail
```

- The "|" symbol is used to pipe the output of the "cut" command to the "xargs" command.
- The "xargs" command is used to pass the path to the log file as an argument to the "tail" command.
- The "tail" command will display the last 10 lines of the log file by default. 


## Any additional comments/context?

TODO:
- [ ] formalize tail logic 
- [ ] add tail optional arguments https://man7.org/linux/man-pages/man1/tail.1.html
    - (already supporting `-f` optional argument)
